### PR TITLE
New: Implement check for already running workflows

### DIFF
--- a/.github/workflows/minesweeper.yml
+++ b/.github/workflows/minesweeper.yml
@@ -8,6 +8,7 @@ jobs:
   minesweeper_job:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       issues: write
 
@@ -27,6 +28,65 @@ jobs:
           echo "ISSUE_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
           echo "REPOSITORY_OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
+
+      # Todo: Rework this into the python application or write own github action for it
+      - name: Check for previous running workflows
+        id: check_previous_workflows
+        if: steps.check_minesweeper.outputs.CONTAINS_MINESWEEPER == 'true'
+        run: |
+          # Step 1: Fetch previous workflow runs
+          RESPONSE=$(curl -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/minesweeper.yml/runs?per_page=10")
+
+          # Step 2: Fetch details of the current workflow run (to get the created_at)
+          RESPONSE_CURRENT=$(curl -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+
+          # Step 3: Initialize env variable
+          PREVIOUS_JOB="false"
+
+          # Step 4: Loop through each run in the API response
+          for row in $(echo "${RESPONSE}" | jq -r '.workflow_runs[] | @base64'); do
+            _jq() {
+              echo ${row} | base64 --decode | jq -r ${1}
+            }
+
+            # Extract run details
+            RUN_ID=$(_jq '.id')
+            RUN_STATUS=$(_jq '.status')
+            RUN_STARTED_AT=$(_jq '.created_at')
+
+            # Step 5: Check if the run is in a relevant status and older than the current run
+            STATUS_CHECK=false
+            case "$RUN_STATUS" in
+              in_progress|queued|waiting|pending|action_required|requested)
+                STATUS_CHECK=true
+                ;;
+              *)
+                STATUS_CHECK=false
+                ;;
+            esac
+
+            TIMESTAMP_CHECK=false
+            # Check if RUN_STARTED_AT is older than the current workflow run's created_at
+            if [[ "$RUN_ID" != "${{ github.run_id }}" && "$RUN_STARTED_AT" && "$(date -u -d "$RUN_STARTED_AT" +%s)" -lt "$(date -u -d "$(echo "$RESPONSE_CURRENT" | jq -r '.created_at')" +%s)" ]]; then
+              TIMESTAMP_CHECK=true
+            fi
+
+            # Step 6: Determine if a previous job meets both status and timestamp criteria
+            if [[ "$STATUS_CHECK" == true && "$TIMESTAMP_CHECK" == true ]]; then
+              PREVIOUS_JOB="true"
+              break
+          done
+
+          # Step 7: Output the final PREVIOUS_JOB status
+          echo "PREVIOUS_JOB=$PREVIOUS_JOB" >> $GITHUB_ENV
        
       - name: Checkout code   
         if: steps.check_minesweeper.outputs.CONTAINS_MINESWEEPER == 'true' 
@@ -46,6 +106,12 @@ jobs:
         if: steps.check_minesweeper.outputs.CONTAINS_MINESWEEPER == 'true'
         run: |
           python src/main.py
+
+      - name: Exit if a previous job is still running
+        if: env.PREVIOUS_JOB == 'true'
+        run: |
+          echo "Another workflow is currently running. Exiting."
+          exit 1
 
       - name: Check for changes
         id: check_changes

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ issue_number = int(os.environ.get("ISSUE_NUMBER"))
 github_token = os.environ.get("GITHUB_TOKEN")
 repository_owner = os.environ.get("REPOSITORY_OWNER")
 repository_name = os.environ.get("GITHUB_REPOSITORY")
+previous_job = os.environ.get("PREVIOUS_JOB")
 
 # check if vars are set
 if issue_number is None or github_token is None or repository_owner is None or repository_name is None:
@@ -20,6 +21,11 @@ github_handler = GithubHandler(github_token, repository_name, issue_number)
 action_key, action_value = github_handler.parse_issue_title()
 minesweeper_handler = MinesweeperHandler()
 markdown_handler = MarkdownHandler(repository_name)
+
+if previous_job == "true":
+    github_handler.create_comment('Action could not be executed: There is currently another workflow running.\nPlease wait for a bit and try your luck later again.')
+    github_handler.close_issue()
+    exit(1)
 
 if action_key == Action.INVALID_MOVE:
     github_handler.create_comment('Action could not be executed: Invalid move.\nIf you think this is a bug, please contact the repository owner.')


### PR DESCRIPTION
This feature should prevent two workflows from running in parallel while not killing the first, but the later ones (concurrency feature would only kill the later one, or queue it and would only allow for 1 slot)